### PR TITLE
Custom clone support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2024-07-25
+
 ### Added
 
+- Custom cloning support
+  - Users of this library can establish a new connection while preserving ledger database
 - Block have time
   - Blocks have fixed 10 minute interval
   - First block have current time
+- Initial relative lock time support
+  - Currently only supports script CSV
+
+### Changed
+
+- Script CSV is now relative, rather than absolute
 
 ## [0.0.3] - 2024-07-16
 
@@ -61,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `get_balance`
 
 [Unreleased]: https://github.com/chainwayxyz/bitcoin-mock-rpc/compare/v0.0.3...HEAD
+[0.0.4]: https://github.com/chainwayxyz/bitcoin-mock-rpc/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/chainwayxyz/bitcoin-mock-rpc/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/chainwayxyz/bitcoin-mock-rpc/compare/0.0.1...v0.0.2
 [0.0.1]: https://github.com/chainwayxyz/bitcoin-mock-rpc/releases/tag/0.0.1

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,12 +13,21 @@ mod rpc_api;
 /// this via trait definitions. This is helpful for choosing different rpc
 /// interface between test and release builds.
 pub trait RpcApiWrapper: RpcApi + std::marker::Sync + std::marker::Send + 'static {
+    /// Create a new RPC connection.
     fn new(url: &str, auth: Auth) -> bitcoincore_rpc::Result<Self>;
+    /// Create a new RPC connection, without any cleanup. Useful for `clone`
+    /// calls.
+    fn new_without_cleanup(url: &str, auth: Auth) -> bitcoincore_rpc::Result<Self>;
 }
 
 /// Compatibility implementation for `bitcoincore_rpc::Client`.
 impl RpcApiWrapper for bitcoincore_rpc::Client {
     fn new(url: &str, auth: Auth) -> bitcoincore_rpc::Result<Self> {
+        bitcoincore_rpc::Client::new(url, auth)
+    }
+
+    /// Same as `new`.
+    fn new_without_cleanup(url: &str, auth: Auth) -> bitcoincore_rpc::Result<Self> {
         bitcoincore_rpc::Client::new(url, auth)
     }
 }
@@ -41,6 +50,15 @@ impl RpcApiWrapper for Client {
     fn new(url: &str, _auth: bitcoincore_rpc::Auth) -> bitcoincore_rpc::Result<Self> {
         Ok(Self {
             ledger: Ledger::new(url),
+        })
+    }
+
+    /// This function will establish a new database connection, while preserving
+    /// it's previous state. Meaning it won't clear database. This is helpful
+    /// for cloning the `Client` structure.
+    fn new_without_cleanup(url: &str, _auth: Auth) -> bitcoincore_rpc::Result<Self> {
+        Ok(Self {
+            ledger: Ledger::new_without_cleanup(url),
         })
     }
 }

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -10,7 +10,6 @@ use std::{
     env,
     sync::{Arc, Mutex},
 };
-
 mod address;
 mod block;
 mod errors;
@@ -38,10 +37,9 @@ impl Ledger {
     /// Panics if SQLite connection can't be established and initial query can't
     /// be run.
     pub fn new(path: &str) -> Self {
-        let temp_dir = env::temp_dir();
-        let path = temp_dir.to_str().unwrap().to_owned() + "/" + path;
+        let path = Ledger::get_database_path(path);
 
-        let database = Connection::open(path).unwrap();
+        let database = Connection::open(path.clone()).unwrap();
 
         Ledger::drop_tables(&database).unwrap();
         Ledger::create_tables(&database).unwrap();
@@ -51,7 +49,34 @@ impl Ledger {
         }
     }
 
-    pub fn drop_tables(database: &Connection) -> Result<(), rusqlite::Error> {
+    /// Connects the ledger, previously created by the `new` call. This function
+    /// won't clean any data from database. Therefore it is a useful function
+    /// for cloning.
+    ///
+    /// This function is needed because `bitcoincore_rpc` doesn't provide a
+    /// `clone` interface. Therefore users of that library need to call `new`
+    /// and establish a new connection to the Bitcoin. This is a solution to
+    /// that problem: We won't clean any mock data and use previously created
+    /// database.
+    ///
+    /// # Panics
+    ///
+    /// Panics if SQLite connection can't be established.
+    pub fn new_without_cleanup(path: &str) -> Self {
+        let path = Ledger::get_database_path(path);
+
+        let database = Connection::open(path.clone()).unwrap();
+
+        Self {
+            database: Arc::new(Mutex::new(database)),
+        }
+    }
+
+    fn get_database_path(path: &str) -> String {
+        env::temp_dir().to_str().unwrap().to_owned() + "/" + path
+    }
+
+    fn drop_tables(database: &Connection) -> Result<(), rusqlite::Error> {
         database.execute_batch(
             "
                 DROP TABLE IF EXISTS blocks;
@@ -67,7 +92,7 @@ impl Ledger {
     /// hold all kind of information about the blockchain. Just holds enough
     /// data to provide a persistent storage for the limited features that the
     /// library provides.
-    pub fn create_tables(database: &Connection) -> Result<(), rusqlite::Error> {
+    fn create_tables(database: &Connection) -> Result<(), rusqlite::Error> {
         database.execute_batch(
             "CREATE TABLE blocks
             (
@@ -108,6 +133,28 @@ impl Ledger {
         )
     }
 }
+
+// impl Clone for Ledger {
+//     fn clone(&self) -> Self {
+//         let database = Connection::open(self.path.clone()).unwrap();
+
+//         Self {
+//             database: Arc::new(Mutex::new(database)),
+//             path: self.path.clone()
+//         }
+//     }
+// }
+
+// impl Drop for Ledger {
+//     fn drop(&mut self) {
+//         println!("Cleaning mock RPC database for {}...", self.path);
+
+//         drop(self.database.clone());
+
+//         let x = std::fs::remove_file(&self.path);
+//         println!("droooppp {:?}", x);
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -134,28 +134,6 @@ impl Ledger {
     }
 }
 
-// impl Clone for Ledger {
-//     fn clone(&self) -> Self {
-//         let database = Connection::open(self.path.clone()).unwrap();
-
-//         Self {
-//             database: Arc::new(Mutex::new(database)),
-//             path: self.path.clone()
-//         }
-//     }
-// }
-
-// impl Drop for Ledger {
-//     fn drop(&mut self) {
-//         println!("Cleaning mock RPC database for {}...", self.path);
-
-//         drop(self.database.clone());
-
-//         let x = std::fs::remove_file(&self.path);
-//         println!("droooppp {:?}", x);
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR introduces a custom clone support. Warning: Not a Rust standard `clone` implementation, because of the limitations with bitcoincore_rpc.