### PR TITLE
Simple UTXO management

### DIFF
--- a/src/client/rpc_api.rs
+++ b/src/client/rpc_api.rs
@@ -398,6 +398,11 @@ impl RpcApi for Client {
             )));
         }
 
+        let utxo = OutPoint { txid: *txid, vout };
+        if self.ledger.is_utxo_spent(utxo) {
+            return Err(LedgerError::Utxo(format!("UTXO {utxo:?} is spent")).into());
+        }
+
         let bestblock = self.get_best_block_hash()?;
 
         let tx = self.get_raw_transaction(txid, None)?;

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod errors;
 mod script;
 mod spending_requirements;
 mod transactions;
+mod utxo;
 
 /// Mock Bitcoin ledger.
 #[derive(Clone, Debug)]
@@ -87,6 +88,7 @@ impl Ledger {
             DROP TABLE IF EXISTS blocks;
             DROP TABLE IF EXISTS mempool;
             DROP TABLE IF EXISTS transactions;
+            DROP TABLE IF EXISTS utxos;
             ",
         )
     }
@@ -124,6 +126,12 @@ impl Ledger {
                 body          BLOB     NOT NULL
 
                 CONSTRAINT txid PRIMARY KEY
+            );
+
+            CREATE TABLE utxos
+            (
+                txid          TEXT     NOT NULL,
+                vout          INTEGER  NOT NULL
             );
             ",
         )

--- a/src/ledger/transactions.rs
+++ b/src/ledger/transactions.rs
@@ -57,6 +57,8 @@ impl Ledger {
 
         self.add_mempool_transaction(txid)?;
 
+        self.handle_transaction_utxos(&transaction)?;
+
         Ok(txid)
     }
 
@@ -265,6 +267,20 @@ impl Ledger {
         tracing::trace!("Transaction's output value in total is {amount}");
 
         amount
+    }
+
+    /// Removes inputs from UTXOs and adds outputs to UTXOs.
+    pub fn handle_transaction_utxos(&self, transaction: &Transaction) -> Result<(), LedgerError> {
+        for input in &transaction.input {
+            self.remove_utxo(input.previous_output)?;
+        }
+
+        let txid = transaction.compute_txid();
+        for vout in 0..(transaction.output.len() as u32) {
+            self.add_utxo(OutPoint { txid, vout })?;
+        }
+
+        Ok(())
     }
 
     /// Creates a `TxIn` with some defaults.

--- a/src/ledger/utxo.rs
+++ b/src/ledger/utxo.rs
@@ -10,7 +10,7 @@ impl Ledger {
             "INSERT INTO utxos (txid, vout) VALUES (?1, ?2)",
             params![utxo.txid.to_string(), utxo.vout],
         ) {
-            return Err(LedgerError::Transaction(format!(
+            return Err(LedgerError::Utxo(format!(
                 "Couldn't add utxo {:?} to ledger: {}",
                 utxo, e
             )));
@@ -37,7 +37,7 @@ impl Ledger {
             "DELETE FROM utxos WHERE txid = ?1 AND vout = ?2",
             params![utxo.txid.to_string(), utxo.vout],
         ) {
-            return Err(LedgerError::Transaction(format!(
+            return Err(LedgerError::Utxo(format!(
                 "Couldn't remove utxo {:?} from ledger: {}",
                 utxo, e
             )));

--- a/src/ledger/utxo.rs
+++ b/src/ledger/utxo.rs
@@ -1,0 +1,75 @@
+//! # UTXO Management
+
+use super::{errors::LedgerError, Ledger};
+use bitcoin::OutPoint;
+use rusqlite::params;
+
+impl Ledger {
+    pub fn add_utxo(&self, utxo: OutPoint) -> Result<(), LedgerError> {
+        if let Err(e) = self.database.lock().unwrap().execute(
+            "INSERT INTO utxos (txid, vout) VALUES (?1, ?2)",
+            params![utxo.txid.to_string(), utxo.vout],
+        ) {
+            return Err(LedgerError::Transaction(format!(
+                "Couldn't add utxo {:?} to ledger: {}",
+                utxo, e
+            )));
+        };
+        tracing::trace!("UTXO {utxo:?} saved");
+
+        Ok(())
+    }
+
+    pub fn is_utxo_spent(&self, utxo: OutPoint) -> bool {
+        match self.database.lock().unwrap().query_row(
+            "SELECT * FROM utxos WHERE txid = ?1 AND vout = ?2",
+            params![utxo.txid.to_string(), utxo.vout],
+            |row| {
+                tracing::info!("row {row:?}");
+                Ok(())
+            },
+        ) {
+            Ok(_) => false,
+            Err(_) => true,
+        }
+    }
+
+    pub fn remove_utxo(&self, utxo: OutPoint) -> Result<(), LedgerError> {
+        if let Err(e) = self.database.lock().unwrap().execute(
+            "DELETE FROM utxos WHERE txid = ?1 AND vout = ?2",
+            params![utxo.txid.to_string(), utxo.vout],
+        ) {
+            return Err(LedgerError::Transaction(format!(
+                "Couldn't remove utxo {:?} from ledger: {}",
+                utxo, e
+            )));
+        };
+        tracing::trace!("UTXO {utxo:?} marked as spent");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ledger::Ledger;
+    use bitcoin::{hashes::Hash, OutPoint, Txid};
+
+    #[test]
+    fn basic_add_remove_utxo() {
+        let ledger = Ledger::new("basic_add_remove_utxo");
+
+        let utxo = OutPoint {
+            txid: Txid::all_zeros(),
+            vout: 0x45,
+        };
+
+        assert!(ledger.is_utxo_spent(utxo));
+
+        ledger.add_utxo(utxo).unwrap();
+        assert!(!ledger.is_utxo_spent(utxo));
+
+        ledger.remove_utxo(utxo).unwrap();
+        assert!(ledger.is_utxo_spent(utxo));
+    }
+}

--- a/src/ledger/utxo.rs
+++ b/src/ledger/utxo.rs
@@ -24,10 +24,7 @@ impl Ledger {
         match self.database.lock().unwrap().query_row(
             "SELECT * FROM utxos WHERE txid = ?1 AND vout = ?2",
             params![utxo.txid.to_string(), utxo.vout],
-            |row| {
-                tracing::info!("row {row:?}");
-                Ok(())
-            },
+            |_| Ok(()),
         ) {
             Ok(_) => false,
             Err(_) => true,

--- a/src/ledger/utxo.rs
+++ b/src/ledger/utxo.rs
@@ -21,14 +21,15 @@ impl Ledger {
     }
 
     pub fn is_utxo_spent(&self, utxo: OutPoint) -> bool {
-        match self.database.lock().unwrap().query_row(
-            "SELECT * FROM utxos WHERE txid = ?1 AND vout = ?2",
-            params![utxo.txid.to_string(), utxo.vout],
-            |_| Ok(()),
-        ) {
-            Ok(_) => false,
-            Err(_) => true,
-        }
+        self.database
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT * FROM utxos WHERE txid = ?1 AND vout = ?2",
+                params![utxo.txid.to_string(), utxo.vout],
+                |_| Ok(()),
+            )
+            .is_err()
     }
 
     pub fn remove_utxo(&self, utxo: OutPoint) -> Result<(), LedgerError> {


### PR DESCRIPTION
This PR adds a simple UTXO management. Every txout are marked as UTXO, regardless of the address they are sent to and marked as spent if used in a tx.